### PR TITLE
TASK: Remove defaultInlineEditor setting

### DIFF
--- a/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
+++ b/Neos.Neos/Documentation/References/NodeTypeDefinition.rst
@@ -290,12 +290,7 @@ The following options are allowed for defining a NodeType:
     ``inline``
 
       ``editor``
-        A way to override default inline editor loaded for this property.
-        Two editors are available out of the box: `ckeditor` (loads CKeditor4) and `ckeditor5` (loads CKeditor5).
-        The default editor is configurable in Settings.yaml under the key `Neos.Neos.Ui.frontendConfiguration.defaultInlineEditor`.
-        It is strongly recommended to start using CKeditor5 today, as the CKeditor4 integration will be deprecated and removed in the future versions.
-        Additional custom inline editors are registered via the `inlineEditors` registry.
-        See `Extending the Content User Interface`_ for the detailed information on the topic.
+        The default inline editor is the CKEditor5.
 
       ``editorOptions``
         This section controls the text formatting options the user has available for this property.


### PR DESCRIPTION
In version 8.0 the CKEditor 4 has been removed, and it is not possible to define a default editor anymore.